### PR TITLE
Fix missing `sudo`s for some actions

### DIFF
--- a/install/roles/elasticsearch/tasks/main.yml
+++ b/install/roles/elasticsearch/tasks/main.yml
@@ -112,6 +112,7 @@
 
 - name: Start elasticsearch service
   command: systemctl start elasticsearch.service
+  become: true
   ignore_errors: true
   when: elasticsearch_updated != 0
 

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: Import Filebeat GPG Key
   rpm_key: key=http://packages.elastic.co/GPG-KEY-elasticsearch
     state=present
+  become: true
   when: (logging_backend != 'fluentd')
 
 - name: Install filebeat rpms
@@ -86,5 +87,6 @@
 
 - name: Restarting rsyslog for fluentd
   command: systemctl restart rsyslog.service
+  become: true
   ignore_errors: true
   when: rsyslog_updated != 0

--- a/install/roles/kibana/tasks/main.yml
+++ b/install/roles/kibana/tasks/main.yml
@@ -42,6 +42,7 @@
 
 - name: Populate elasticsearch index with local logs via fluentd
   command: systemctl restart rsyslog.service
+  become: true
   ignore_errors: true
   when: rsyslog_updated != 0
 
@@ -84,6 +85,7 @@
 
 - name: Create kibana admin user
   command: htpasswd -b -c /etc/nginx/htpasswd.users {{kibana_user}} {{kibana_password}}
+  become: true
   ignore_errors: true
   when: kibana_user_pwfile_exists != 0
 
@@ -100,6 +102,7 @@
   command: openssl req -subj '/CN={{ ansible_fqdn }}/' -config /etc/pki/tls/openssl_extras.cnf \
     -x509 -days 3650 -batch -nodes -newkey rsa:2048 -keyout /etc/pki/tls/private/filebeat-forwarder.key \
     -out /etc/pki/tls/certs/filebeat-forwarder.crt
+  become: true
   ignore_errors: true
   when: filebeat_forwarder_ssl_exists != 0
 
@@ -110,6 +113,7 @@
 
 - name: Copy Filebeat forwarder SSL certificate
   command: cp /etc/pki/tls/certs/filebeat-forwarder.crt /usr/share/nginx/html/filebeat-forwarder.crt
+  become: true
   ignore_errors: true
   when: filebeat_forwarder_ssl_client_copy_exists != 0
 

--- a/install/roles/logstash/tasks/main.yml
+++ b/install/roles/logstash/tasks/main.yml
@@ -89,6 +89,7 @@
     regexp: '^ Extensions for a typical CA'
     insertbefore: '# Extensions for a typical CA'
     backup: yes
+  become: true
   when: subjectAltName_exists.stdout|int == 0
 
 - name: Load filebeat JSON index template

--- a/install/roles/nginx/tasks/main.yml
+++ b/install/roles/nginx/tasks/main.yml
@@ -19,12 +19,14 @@
 # SELinux boolean for nginx
 - name: Apply SELinux boolean httpd_can_network_connect
   seboolean: name=httpd_can_network_connect state=yes persistent=yes
+  become: true
 
 # create /etc/nginx/conf.d/ directory
 - name: Create nginx directory structure
   file: path=/etc/nginx/conf.d/
     state=directory
     mode=0755
+  become: true
 
 # deploy kibana.conf with FQDN
 - name: Setup nginx reverse proxy for kibana
@@ -50,11 +52,13 @@
 # start nginx service
 - name: Start nginx service
   command: systemctl restart nginx.service
+  become: true
   ignore_errors: true
   when: nginx_needs_restart != 0
 
 - name: Check if nginx is in use
   shell: systemctl is-enabled nginx.service | egrep -qv 'masked|disabled'
+  become: true
   register: nginx_in_use
   ignore_errors: yes
   tags:
@@ -64,6 +68,7 @@
 
 - name: Set nginx to start on boot
   command: systemctl enable nginx.service
+  become: true
   ignore_errors: true
   when: nginx_in_use.rc != 0
 
@@ -75,6 +80,7 @@
 # Firewalld
 - name: Determine if firewalld is in use
   shell: systemctl is-enabled firewalld.service | egrep -qv 'masked|disabled'
+  become: true
   ignore_errors: true
   register: firewalld_in_use
   no_log: true


### PR DESCRIPTION
Several commands like `systemctl`, `semanage` or writing to `/etc` need
elevated rights.

This patch adds `become: true` to those commands so that this playbook
can be run with any user, not just root.
