### PR TITLE
2.4 branch, #23 Add a retry and retry delay to 'Load filebeat JSON index template'

### DIFF
--- a/install/roles/logstash/tasks/main.yml
+++ b/install/roles/logstash/tasks/main.yml
@@ -91,13 +91,19 @@
     backup: yes
   when: subjectAltName_exists.stdout|int == 0
 
+# Elasticsearch may still be starting at this point (depending on your system speed)
+# if we can't connect, wait a few seconds then try again
 - name: Load filebeat JSON index template
   uri:
     url: http://localhost:9200/_template/filebeat?pretty
     method: POST
     body: "{{ lookup('file', 'filebeat-index-template.json') }}"
     body_format: json
-  ignore_errors: true
+    return_content: yes
+  register: filebeatJSON_output
+  until: '"json" in filebeatJSON_output and filebeatJSON_output.json.acknowledged == true'
+  retries: 30
+  delay: 10
   become: true
 
 - name: Enable logstash service


### PR DESCRIPTION
Update the logstash role, task 'Load filebeat JSON index template' to detect a failure to load, and retry a few times.

This one I have tested but only in the context of my own version, which I've derived from your scripts.

I am also just learning Ansible so I hope I've done everything right.  Please let me know if anything doesn't look right.