### PR TITLE
Ubuntu beats

### DIFF
--- a/install/roles/elk_client/tasks/main.yml
+++ b/install/roles/elk_client/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 
+
+#CentOS Installation
 - name: Copy ElasticSearch yum repo file
   copy:
     src=elk.repo
@@ -8,18 +10,55 @@
     group=root
     mode=0644
   become: true
+  when:
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 - name: Creates ELK Cert Directory
   file:
     path: /etc/beat
     state: directory
     mode: 0755
+  when:
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 - name: Import ElasticSearch GPG Key
   rpm_key: key=http://packages.elastic.co/GPG-KEY-elasticsearch
     state=present
+  when:
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
+#Debian/Ubuntu Installation
+- name: Install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+  when: 
+    - ansible_distribution == 'Debian'
 
+- name: Add ElasticSearch Apt Signing Key
+  apt_key:
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    state: present
+  when:
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+- name: Add ElasticSearch Repository
+  apt_repository:
+    repo: deb https://artifacts.elastic.co/packages/5.x/apt stable main
+    state: present
+  when:
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+- name: Run the equivalent of "apt-get update"
+  apt:
+    update_cache: yes
+  when:
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+  
+#SSL Certificate Steps
 - name: Check ELK server SSL client certificate
   stat: path=/etc/beat/beat-forwarder.crt
   ignore_errors: true

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -2,12 +2,28 @@
 #
 # install/run filebeat elk client
 #
+
+#CentOS Installation of Filebeat
 - name: Install filebeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
     - filebeat
-  when: (logging_backend != 'fluentd')
+  when:
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Installation of Filebeat
+- name: Install filebeat package
+  apt: name={{ item }} 
+  state: present
+  become: true
+  with_items:
+    - filebeat
+  when:
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
 - name: Generate filebeat configuration template
   template:
@@ -17,31 +33,56 @@
     group=root
     mode=0644
   become: true
-  when: (logging_backend != 'fluentd')
+  when:
+    - logging_backend != 'fluentd'
   register: filebeat_needs_restart
 
+#Centos Start Filebeat Service
 - name: Start filebeat service
   command: systemctl start filebeat.service
   ignore_errors: true
   become: true
-  when: ((filebeat_needs_restart != 0) and (logging_backend != 'fluentd'))
+  when: 
+    - filebeat_needs_restart != 0
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 - name: Setup filebeat service
   service: name=filebeat state=started enabled=true
   become: true
-  when: (logging_backend != 'fluentd')
+  when: 
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
+- name: Enable Filebeat Service to Start on Boot Debian/Ubuntu
+  command: update-rc.d filebeat defaults 95 10
+  ignore_errors: true
+  become: true
+  when: 
+    - filebeat_needs_restart != 0 
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+###################################### RSYSLOG for Fluentd Setup ##################################################
 - name: Install rsyslogd for fluentd
   yum: name={{ item }} state=present
   become: true
   with_items:
     - rsyslog
-  when: (logging_backend == 'fluentd')
+  when:
+    - logging_backend = 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 - name: Setup rsyslogd for fluentd
   lineinfile: dest=/etc/rsyslog.conf \
           line="*.* @{{ elk_server }}:{{ fluentd_syslog_port }}"
-  when: (logging_backend == 'fluentd')
+  when:
+    - logging_backend = 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
   register: rsyslog_updated
 
 - name: Setup common OpenStack rsyslog logging
@@ -53,9 +94,16 @@
     mode=0644
   become: true
   register: rsyslog_updated
-  when: (logging_backend == 'fluentd')
+  when:
+    - logging_backend = 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 - name: Restarting rsyslog for fluentd
   command: systemctl restart rsyslog.service
   ignore_errors: true
-  when: rsyslog_updated != 0
+  when: 
+    - rsyslog_updated != 0
+    - logging_backend = 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -40,36 +40,12 @@
     - logging_backend != 'fluentd'
   register: filebeat_needs_restart
 
-
-#Centos Start Filebeat Service
-- name: Start filebeat service
-  command: systemctl start filebeat.service
-  ignore_errors: true
-  become: true
-  when: 
-    - filebeat_needs_restart != 0
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
-
 - name: Setup filebeat service
   service: name=filebeat state=started enabled=true
   become: true
   when: 
     - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-
-#Debian/Ubuntu Service Setup
-- name: Enable Filebeat Service to Start on Boot Debian/Ubuntu
-  command: update-rc.d filebeat defaults 95 10
-  ignore_errors: true
-  become: true
-  when: 
-    - filebeat_needs_restart != 0 
-    - logging_backend != 'fluentd'
-    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
 ###################################### RSYSLOG for Fluentd Setup ##################################################
 - name: Install rsyslogd for fluentd

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -14,6 +14,7 @@
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
+
 #Debian/Ubuntu Installation of Filebeat
 - name: Install filebeat package
   apt: name={{ item }} 
@@ -25,6 +26,8 @@
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
+
+#Generate config on all platforms
 - name: Generate filebeat configuration template
   template:
     src=filebeat.yml.j2
@@ -36,6 +39,7 @@
   when:
     - logging_backend != 'fluentd'
   register: filebeat_needs_restart
+
 
 #Centos Start Filebeat Service
 - name: Start filebeat service
@@ -56,6 +60,8 @@
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
+
+#Debian/Ubuntu Service Setup
 - name: Enable Filebeat Service to Start on Boot Debian/Ubuntu
   command: update-rc.d filebeat defaults 95 10
   ignore_errors: true

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -17,8 +17,9 @@
 
 #Debian/Ubuntu Installation of Filebeat
 - name: Install filebeat package
-  apt: name={{ item }} 
-  state: present
+  apt: 
+    name: "{{ item }}" 
+    state: present
   become: true
   with_items:
     - filebeat

--- a/install/roles/heartbeat/tasks/main.yml
+++ b/install/roles/heartbeat/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 #
-# install/run heartbeatbeat elk client
+# install/run heartbeat elk client
 #
 
 #CentOS Installation of Heartbeat
@@ -15,7 +15,6 @@
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 #Debian/Ubuntu Installation of Heartbeat
-#Debian/Ubuntu Installation of Filebeat
 - name: Install Heartbeat package
   apt: name={{ item }} 
   state: present
@@ -62,6 +61,6 @@
   ignore_errors: true
   become: true
   when: 
-    - filebeat_needs_restart != 0 
+    - heartbeat_needs_restart != 0 
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/install/roles/heartbeat/tasks/main.yml
+++ b/install/roles/heartbeat/tasks/main.yml
@@ -3,7 +3,7 @@
 # install/run heartbeat elk client
 #
 
-#CentOS Installation of Heartbeat
+#CentOS Installation of heartbeat
 - name: Install heartbeat rpms
   yum: name={{ item }} state=present
   become: true
@@ -14,8 +14,9 @@
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-#Debian/Ubuntu Installation of Heartbeat
-- name: Install Heartbeat package
+#Debian/Ubuntu Installation of heartbeat
+
+- name: Install heartbeat package
   apt: name={{ item }} 
   state: present
   become: true
@@ -37,30 +38,19 @@
   register: heartbeat_needs_restart
 
 #Centos Service Configuration
-- name: Start heartbeat service (CentOS)
-  command: systemctl start heartbeat.service
-  ignore_errors: true
-  become: true
-  when: 
-    - heartbeat_needs_restart != 0
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+#- name: Start heartbeat service (CentOS)
+##  command: systemctl start heartbeat.service
+#  ignore_errors: true
+#  become: true
+#  when: 
+#    - heartbeat_needs_restart != 0
+#    - logging_backend != 'fluentd'
+#    - ansible_distribution == 'CentOS'
+#    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup heartbeat service (CentOS)
+- name: Setup heartbeat service (Systemd)
   service: name=heartbeat state=started enabled=true
   become: true
   when:
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
-
-#Debian/Ubuntu Service Setup
-- name: Enable Heartbeat Service to Start on Boot Debian/Ubuntu
-  command: update-rc.d heartbeat defaults 95 10
-  ignore_errors: true
-  become: true
-  when: 
-    - heartbeat_needs_restart != 0 
-    - logging_backend != 'fluentd'
-    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+    - logging_backend != 'fluentd'.
+    - heartbeat_needs_restart != 0

--- a/install/roles/heartbeat/tasks/main.yml
+++ b/install/roles/heartbeat/tasks/main.yml
@@ -17,8 +17,9 @@
 #Debian/Ubuntu Installation of heartbeat
 
 - name: Install heartbeat package
-  apt: name={{ item }} 
-  state: present
+  apt: 
+    name: "{{ item }}" 
+    state: present
   become: true
   with_items:
     - heartbeat

--- a/install/roles/heartbeat/tasks/main.yml
+++ b/install/roles/heartbeat/tasks/main.yml
@@ -2,12 +2,29 @@
 #
 # install/run heartbeatbeat elk client
 #
+
+#CentOS Installation of Heartbeat
 - name: Install heartbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
     - heartbeat
-  when: (logging_backend != 'fluentd')
+  when: 
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Installation of Heartbeat
+#Debian/Ubuntu Installation of Filebeat
+- name: Install Heartbeat package
+  apt: name={{ item }} 
+  state: present
+  become: true
+  with_items:
+    - heartbeat
+  when:
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
 - name: Generate heartbeat configuration template
   template:
@@ -20,13 +37,31 @@
   when: (logging_backend != 'fluentd')
   register: heartbeat_needs_restart
 
-- name: Start heartbeat service
+#Centos Service Configuration
+- name: Start heartbeat service (CentOS)
   command: systemctl start heartbeat.service
   ignore_errors: true
   become: true
-  when: ((heartbeat_needs_restart != 0) and (logging_backend != 'fluentd'))
+  when: 
+    - heartbeat_needs_restart != 0
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup heartbeat service
+- name: Setup heartbeat service (CentOS)
   service: name=heartbeat state=started enabled=true
   become: true
-  when: (logging_backend != 'fluentd')
+  when:
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Service Setup
+- name: Enable Heartbeat Service to Start on Boot Debian/Ubuntu
+  command: update-rc.d heartbeat defaults 95 10
+  ignore_errors: true
+  become: true
+  when: 
+    - filebeat_needs_restart != 0 
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/install/roles/metricbeat/tasks/main.yml
+++ b/install/roles/metricbeat/tasks/main.yml
@@ -1,13 +1,30 @@
 ---
 #
-# install/run packetbeat elk client
+# install/run metricbeat elk client
 #
+
+#CentOS Installation of metricbeat
 - name: Install metricbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
     - metricbeat
-  when: (logging_backend != 'fluentd')
+  when: 
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Installation of metricbeat
+
+- name: Install metricbeat package
+  apt: name={{ item }} 
+  state: present
+  become: true
+  with_items:
+    - metricbeat
+  when:
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
 - name: Generate metricbeat configuration template
   template:
@@ -20,13 +37,31 @@
   when: (logging_backend != 'fluentd')
   register: metricbeat_needs_restart
 
-- name: Start metricbeat service
+#Centos Service Configuration
+- name: Start metricbeat service (CentOS)
   command: systemctl start metricbeat.service
   ignore_errors: true
   become: true
-  when: ((metricbeat_needs_restart != 0) and (logging_backend != 'fluentd'))
+  when: 
+    - metricbeat_needs_restart != 0
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup metricbeat service
+- name: Setup metricbeat service (CentOS)
   service: name=metricbeat state=started enabled=true
   become: true
-  when: (logging_backend != 'fluentd')
+  when:
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Service Setup
+- name: Enable metricbeat Service to Start on Boot Debian/Ubuntu
+  command: update-rc.d metricbeat defaults 95 10
+  ignore_errors: true
+  become: true
+  when: 
+    - metricbeat_needs_restart != 0 
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/install/roles/metricbeat/tasks/main.yml
+++ b/install/roles/metricbeat/tasks/main.yml
@@ -1,55 +1,55 @@
 ---
 #
-# install/run metricbeat elk client
+# install/run packetbeat elk client
 #
 
-#CentOS Installation of metricbeat
-- name: Install metricbeat rpms
+#CentOS Installation of packetbeat
+- name: Install packetbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
-    - metricbeat
+    - packetbeat
   when: 
     - logging_backend != 'fluentd'
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-#Debian/Ubuntu Installation of metricbeat
+#Debian/Ubuntu Installation of packetbeat
 
-- name: Install metricbeat package
+- name: Install packetbeat package
   apt: name={{ item }} 
   state: present
   become: true
   with_items:
-    - metricbeat
+    - packetbeat
   when:
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
-- name: Generate metricbeat configuration template
+- name: Generate packetbeat configuration template
   template:
-    src=metricbeat.yml.j2
-    dest=/etc/metricbeat/metricbeat.yml
+    src=packetbeat.yml.j2
+    dest=/etc/packetbeat/packetbeat.yml
     owner=root
     group=root
     mode=0644
   become: true
   when: (logging_backend != 'fluentd')
-  register: metricbeat_needs_restart
+  register: packetbeat_needs_restart
 
 #Centos Service Configuration
-- name: Start metricbeat service (CentOS)
-  command: systemctl start metricbeat.service
+- name: Start packetbeat service (CentOS)
+  command: systemctl start packetbeat.service
   ignore_errors: true
   become: true
   when: 
-    - metricbeat_needs_restart != 0
+    - packetbeat_needs_restart != 0
     - logging_backend != 'fluentd'
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup metricbeat service (CentOS)
-  service: name=metricbeat state=started enabled=true
+- name: Setup packetbeat service (CentOS)
+  service: name=packetbeat state=started enabled=true
   become: true
   when:
     - logging_backend != 'fluentd'
@@ -57,11 +57,11 @@
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
 #Debian/Ubuntu Service Setup
-- name: Enable metricbeat Service to Start on Boot Debian/Ubuntu
-  command: update-rc.d metricbeat defaults 95 10
+- name: Enable packetbeat Service to Start on Boot Debian/Ubuntu
+  command: update-rc.d packetbeat defaults 95 10
   ignore_errors: true
   become: true
   when: 
-    - metricbeat_needs_restart != 0 
+    - packetbeat_needs_restart != 0 
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/install/roles/metricbeat/tasks/main.yml
+++ b/install/roles/metricbeat/tasks/main.yml
@@ -17,8 +17,9 @@
 #Debian/Ubuntu Installation of metricbeat
 
 - name: Install metricbeat package
-  apt: name={{ item }} 
-  state: present
+  apt: 
+    name: "{{ item }}" 
+    state: present
   become: true
   with_items:
     - metricbeat

--- a/install/roles/metricbeat/tasks/main.yml
+++ b/install/roles/metricbeat/tasks/main.yml
@@ -1,67 +1,56 @@
 ---
 #
-# install/run packetbeat elk client
+# install/run metricbeat elk client
 #
 
-#CentOS Installation of packetbeat
-- name: Install packetbeat rpms
+#CentOS Installation of metricbeat
+- name: Install metricbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
-    - packetbeat
+    - metricbeat
   when: 
     - logging_backend != 'fluentd'
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-#Debian/Ubuntu Installation of packetbeat
+#Debian/Ubuntu Installation of metricbeat
 
-- name: Install packetbeat package
+- name: Install metricbeat package
   apt: name={{ item }} 
   state: present
   become: true
   with_items:
-    - packetbeat
+    - metricbeat
   when:
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
-- name: Generate packetbeat configuration template
+- name: Generate metricbeat configuration template
   template:
-    src=packetbeat.yml.j2
-    dest=/etc/packetbeat/packetbeat.yml
+    src=metricbeat.yml.j2
+    dest=/etc/metricbeat/metricbeat.yml
     owner=root
     group=root
     mode=0644
   become: true
   when: (logging_backend != 'fluentd')
-  register: packetbeat_needs_restart
+  register: metricbeat_needs_restart
 
 #Centos Service Configuration
-- name: Start packetbeat service (CentOS)
-  command: systemctl start packetbeat.service
-  ignore_errors: true
-  become: true
-  when: 
-    - packetbeat_needs_restart != 0
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+#- name: Start metricbeat service (CentOS)
+##  command: systemctl start metricbeat.service
+#  ignore_errors: true
+#  become: true
+#  when: 
+#    - metricbeat_needs_restart != 0
+#    - logging_backend != 'fluentd'
+#    - ansible_distribution == 'CentOS'
+#    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup packetbeat service (CentOS)
-  service: name=packetbeat state=started enabled=true
+- name: Setup metricbeat service (Systemd)
+  service: name=metricbeat state=started enabled=true
   become: true
   when:
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
-
-#Debian/Ubuntu Service Setup
-- name: Enable packetbeat Service to Start on Boot Debian/Ubuntu
-  command: update-rc.d packetbeat defaults 95 10
-  ignore_errors: true
-  become: true
-  when: 
-    - packetbeat_needs_restart != 0 
-    - logging_backend != 'fluentd'
-    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+    - logging_backend != 'fluentd'.
+    - metricbeat_needs_restart != 0

--- a/install/roles/packetbeat/tasks/main.yml
+++ b/install/roles/packetbeat/tasks/main.yml
@@ -1,32 +1,67 @@
 ---
 #
-# install/run packetbeat elk client
+# install/run metricbeat elk client
 #
-- name: Install packetbeat rpms
+
+#CentOS Installation of metricbeat
+- name: Install metricbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
-    - packetbeat
-  when: (logging_backend != 'fluentd')
+    - metricbeat
+  when: 
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Generate packetbeat configuration template
+#Debian/Ubuntu Installation of metricbeat
+
+- name: Install metricbeat package
+  apt: name={{ item }} 
+  state: present
+  become: true
+  with_items:
+    - metricbeat
+  when:
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+
+- name: Generate metricbeat configuration template
   template:
-    src=packetbeat.yml.j2
-    dest=/etc/packetbeat/packetbeat.yml
+    src=metricbeat.yml.j2
+    dest=/etc/metricbeat/metricbeat.yml
     owner=root
     group=root
     mode=0644
   become: true
   when: (logging_backend != 'fluentd')
-  register: packetbeat_needs_restart
+  register: metricbeat_needs_restart
 
-- name: Start packetbeat service
-  command: systemctl start packetbeat.service
+#Centos Service Configuration
+- name: Start metricbeat service (CentOS)
+  command: systemctl start metricbeat.service
   ignore_errors: true
   become: true
-  when: ((packetbeat_needs_restart != 0) and (logging_backend != 'fluentd'))
+  when: 
+    - metricbeat_needs_restart != 0
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup packetbeat service
-  service: name=packetbeat state=started enabled=true
+- name: Setup metricbeat service (CentOS)
+  service: name=metricbeat state=started enabled=true
   become: true
-  when: (logging_backend != 'fluentd')
+  when:
+    - logging_backend != 'fluentd'
+    - ansible_distribution == 'CentOS'
+    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
+
+#Debian/Ubuntu Service Setup
+- name: Enable metricbeat Service to Start on Boot Debian/Ubuntu
+  command: update-rc.d metricbeat defaults 95 10
+  ignore_errors: true
+  become: true
+  when: 
+    - metricbeat_needs_restart != 0 
+    - logging_backend != 'fluentd'
+    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')

--- a/install/roles/packetbeat/tasks/main.yml
+++ b/install/roles/packetbeat/tasks/main.yml
@@ -1,67 +1,46 @@
 ---
 #
-# install/run metricbeat elk client
+# install/run packetbeat elk client
 #
 
-#CentOS Installation of metricbeat
-- name: Install metricbeat rpms
+#CentOS Installation of packetbeat
+- name: Install packetbeat rpms
   yum: name={{ item }} state=present
   become: true
   with_items:
-    - metricbeat
+    - packetbeat
   when: 
     - logging_backend != 'fluentd'
     - ansible_distribution == 'CentOS'
     - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-#Debian/Ubuntu Installation of metricbeat
+#Debian/Ubuntu Installation of packetbeat
 
-- name: Install metricbeat package
+- name: Install packetbeat package
   apt: name={{ item }} 
   state: present
   become: true
   with_items:
-    - metricbeat
+    - packetbeat
   when:
     - logging_backend != 'fluentd'
     - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
 
-- name: Generate metricbeat configuration template
+- name: Generate packetbeat configuration template
   template:
-    src=metricbeat.yml.j2
-    dest=/etc/metricbeat/metricbeat.yml
+    src=packetbeat.yml.j2
+    dest=/etc/packetbeat/packetbeat.yml
     owner=root
     group=root
     mode=0644
   become: true
   when: (logging_backend != 'fluentd')
-  register: metricbeat_needs_restart
+  register: packetbeat_needs_restart
 
-#Centos Service Configuration
-- name: Start metricbeat service (CentOS)
-  command: systemctl start metricbeat.service
-  ignore_errors: true
-  become: true
-  when: 
-    - metricbeat_needs_restart != 0
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
 
-- name: Setup metricbeat service (CentOS)
-  service: name=metricbeat state=started enabled=true
+- name: Setup packetbeat service (Systemd)
+  service: name=packetbeat state=started enabled=true
   become: true
   when:
-    - logging_backend != 'fluentd'
-    - ansible_distribution == 'CentOS'
-    - (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
-
-#Debian/Ubuntu Service Setup
-- name: Enable metricbeat Service to Start on Boot Debian/Ubuntu
-  command: update-rc.d metricbeat defaults 95 10
-  ignore_errors: true
-  become: true
-  when: 
-    - metricbeat_needs_restart != 0 
-    - logging_backend != 'fluentd'
-    - (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
+    - logging_backend != 'fluentd'.
+    - packetbeat_needs_restart != 0

--- a/install/roles/packetbeat/tasks/main.yml
+++ b/install/roles/packetbeat/tasks/main.yml
@@ -17,8 +17,9 @@
 #Debian/Ubuntu Installation of packetbeat
 
 - name: Install packetbeat package
-  apt: name={{ item }} 
-  state: present
+  apt: 
+    name: "{{ item }}" 
+    state: present
   become: true
   with_items:
     - packetbeat


### PR DESCRIPTION
I added support for Ubuntu and Debian hosts related to the beats. I added the GPG checking, APT repository, and installation based on the same conditionals but also 

I also removed an extraneous step from the setup of each beat. We were trying to do both a command and service module to set it up. This simplified each playbook a little.

I don't have any ubuntu 14 or debian 6 hosts to check and see if the service module also works on upstart systems without flaws. The [docs](http://docs.ansible.com/ansible/latest/service_module.html) say they do, but we'd have to test that.

