### PR TITLE
feat: add support for Fedora and EL8 ELK clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ansible Playbook for setting up the ELK/EFK Stack and Filebeat client on remote 
 [![CI](https://travis-ci.org/sadsfae/ansible-elk.svg?branch=master)](https://travis-ci.org/sadsfae/ansible-elk)
 
 ## What does it do?
-   - Automated deployment of a full 6.8+ ELK or EFK stack (Elasticsearch, Logstash/Fluentd, Kibana)
+   - Automated deployment of a full 6.x series ELK or EFK stack (Elasticsearch, Logstash/Fluentd, Kibana)
      * `5.6` and `2.4` ELK versions are maintained as branches and `master` branch will be 6.x currently.
      * Uses Nginx as a reverse proxy for Kibana, or optionally Apache via `apache_reverse_proxy: true`
      * Generates SSL certificates for Filebeat or Logstash-forwarder
@@ -23,6 +23,7 @@ Ansible Playbook for setting up the ELK/EFK Stack and Filebeat client on remote 
 
 ## Requirements
    - RHEL7 or CentOS7 server/client with no modifications
+   - RHEL7/CentOS7 or Fedora for ELK clients using Filebeat
    - ELK/EFK server with at least 8G of memory (you can try with less but 5.x series is quite demanding - try 2.4 series if you have scarce resources).
    - You may want to modify ```vm.swappiness``` as ELK/EFK is demanding and swapping kills the responsiveness.
      - I am leaving this up to your judgement.
@@ -33,6 +34,7 @@ sysctl -p
 
 ## Notes
    - Current ELK version is 6.x but you can checkout the 5.6 or 2.4 branch if you want that series
+   - I will update this playbook for major ELK versions going forward as time allows.
    - Sets the nginx htpasswd to admin/admin initially
    - nginx ports default to 80/8080 for Kibana and SSL cert retrieval (configurable)
    - Uses OpenJDK for Java

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -2,11 +2,29 @@
 #
 # install/run filebeat elk client
 #
+- name: Symlink Python to Python3 for EL8/Fedora
+  file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    state: link
+  when: ansible_distribution_major_version|int >= 8 and ansible_python_version|int < 3.6
+  ignore_errors: true
+
+- name: Switch to Python3 by Default (Fedora/EL8)
+  command: alternatives --install /usr/bin/python python /usr/bin/python3 1
+  when: ansible_python_version|int < 3.6 and ansible_distribution_major_version|int >= 8
+
 - name: Install filebeat rpms
   yum:
     name: filebeat
   become: true
   when: (logging_backend != 'fluentd')
+
+- name: Install filebeat rpms (EL8/Fedora)
+  dnf:
+    name: filebeat
+  become: true
+  when: logging_backend != 'fluentd' and ansible_distribution_major_version|int >= 8
 
 - name: Generate filebeat configuration template
   template:
@@ -37,6 +55,12 @@
     name: rsyslog
   become: true
   when: (logging_backend == 'fluentd')
+
+- name: Install rsyslogd for fluentd (EL8/Fedora)
+  dnf:
+    name: rsyslog
+  become: true
+  when: logging_backend == 'fluentd' and ansible_distribution_major_version|int >= 8
 
 - name: Setup rsyslogd for fluentd
   lineinfile: dest=/etc/rsyslog.conf \

--- a/install/roles/instructions/tasks/main.yml
+++ b/install/roles/instructions/tasks/main.yml
@@ -39,4 +39,8 @@
   debug: msg="*** 5) Click on Discover ***"
 
 - name: Print filebeat client setup instructions
-  debug: msg="*** 6) ansible-playbook -i hosts install/elk_client.yml --extra-vars 'elk_server={{ ansible_default_ipv4.address }}' to setup clients ***"
+  debug:
+    "msg": [
+      "*** 6) ansible-playbook -i hosts install/elk_client.yml --extra-vars 'elk_server={{ ansible_default_ipv4.address }}' to setup clients",
+      "*** To add new clients later, running on this command is required ***"
+    ]


### PR DESCRIPTION
* Add support for dnf module for Fedora and EL8 ELK Clients (filebeat)
* Include a python2 to python3 fix for Fedora 29

fixes: https://github.com/sadsfae/ansible-elk/issues/84