### PR TITLE
Remove IPv6 Nginx listen port, fix Handler.

### DIFF
--- a/install/roles/logstash/tasks/main.yml
+++ b/install/roles/logstash/tasks/main.yml
@@ -134,7 +134,7 @@
     - { regexp: 'NETWORKING_IPV6=.*', line: 'NETWORKING_IPV6=NO' }
     - { regexp: 'IPV6INIT=.*', line: 'IPV6INIT=no' }
   notify:
-    - restart network
+    - restart Network
     - restart NetworkManager
   when: ansible_os_family == 'RedHat'
 

--- a/install/roles/nginx/templates/nginx.conf.j2
+++ b/install/roles/nginx/templates/nginx.conf.j2
@@ -34,7 +34,6 @@ http {
 
     server {
         listen       {{elk_server_ssl_cert_port}} default_server;
-        listen       [::]:{{elk_server_ssl_cert_port}} default_server;
         server_name  _;
         root         /usr/share/nginx/html;
 


### PR DESCRIPTION
* There was a duplicate line in nginx.conf for Listen
* Remove IPv6/IPv4 combined listener directive in kibana.conf
* Fix typo for 'restart Network' handler.

fixes: https://github.com/sadsfae/ansible-elk/issues/90