### PR TITLE
Make rmmod ipv6 handler more modular.

### DIFF
--- a/install/roles/logstash/tasks/main.yml
+++ b/install/roles/logstash/tasks/main.yml
@@ -115,11 +115,16 @@
     - net.ipv6.conf.default.disable_ipv6
     - net.ipv6.conf.lo.disable_ipv6
 
-- name: Disable IPv6 via modprobe
+- name: Determine if ipv6 is a loadable module
+  command: /sbin/lsmod | grep ipv6 | grep -v nf
+  register: ipv6loadable
+  ignore_errors: true
+
+- name: Disable IPv6 via rmmod
   lineinfile: "dest=/etc/modprobe.conf line='install ipv6 /bin/true' create=yes"
   notify:
     - rmmodipv6
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ipv6loadable.rc != 1
 
 - include: ipv6-grub-disable.yml
 


### PR DESCRIPTION
Although it seems like EL7 builds ipv6 into the kernel, let's check
that it is indeed the case.  If so we'll use rmmod, if not we'll
just continue.