### PR TITLE
Make settings for disabling ipv6 more flexible.

### DIFF
--- a/install/roles/logstash/tasks/main.yml
+++ b/install/roles/logstash/tasks/main.yml
@@ -114,6 +114,7 @@
     - net.ipv6.conf.all.disable_ipv6
     - net.ipv6.conf.default.disable_ipv6
     - net.ipv6.conf.lo.disable_ipv6
+  ignore_errors: true
 
 - name: Determine if ipv6 is a loadable module
   command: /sbin/lsmod | grep ipv6 | grep -v nf
@@ -125,6 +126,7 @@
   notify:
     - rmmodipv6
   when: ansible_os_family == 'RedHat' and ipv6loadable.rc != 1
+  ignore_errors: true
 
 - include: ipv6-grub-disable.yml
 
@@ -142,6 +144,7 @@
     - restart Network
     - restart NetworkManager
   when: ansible_os_family == 'RedHat'
+  ignore_errors: true
 
 # X-Pack requires additional authentication
 - name: Load filebeat JSON index template (X-Pack enabled)


### PR DESCRIPTION
We should ignore errors on tasks that aren't fatal to core playbook execution.  It appears `/proc/sys/net/ipv6/conf/lo/disable_ipv6` does not exist on EL7 but it does on Fedora and probably other distributions.