### PR TITLE
Better separate EL7/EL8 Filebeat clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ansible Playbook for setting up the ELK/EFK Stack and Filebeat client on remote 
 
 ## Requirements
    - RHEL7 or CentOS7 server/client with no modifications
-   - RHEL7/CentOS7 or Fedora for ELK clients using Filebeat
+   - RHEL7/CentOS7, Rocky or Fedora for ELK clients using Filebeat
    - ELK/EFK server with at least 8G of memory (you can try with less but 5.x series is quite demanding - try 2.4 series if you have scarce resources).
    - You may want to modify ```vm.swappiness``` as ELK/EFK is demanding and swapping kills the responsiveness.
      - I am leaving this up to your judgement.

--- a/install/roles/filebeat/tasks/main.yml
+++ b/install/roles/filebeat/tasks/main.yml
@@ -2,6 +2,12 @@
 #
 # install/run filebeat elk client
 #
+- name: Install Python3 for some Minimal Setups (Fedora/EL8)
+  dnf:
+    name: python3
+  become: true
+  when: ansible_distribution_major_version|int >= 8
+
 - name: Symlink Python to Python3 for EL8/Fedora
   file:
     src: /usr/bin/python3
@@ -18,7 +24,7 @@
   yum:
     name: filebeat
   become: true
-  when: (logging_backend != 'fluentd')
+  when: (logging_backend != 'fluentd') and ansible_distribution_major_version|int <= 7
 
 - name: Install filebeat rpms (EL8/Fedora)
   dnf:


### PR DESCRIPTION
* Separate package installation better between EL7/EL8
* Support Rocky Linux (we always did but we do now, too).